### PR TITLE
Fix mixin name for breakpoint adjustment

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -385,7 +385,7 @@
   float: left;
 
   @include breakpoint($large) {
-    @include pre(2.5 of 12);
+    @include prefix(2.5 of 12);
   }
 
   a {


### PR DESCRIPTION
Correct the mixin name from 'pre' to 'prefix' to ensure proper breakpoint adjustments in the stylesheet.