### PR TITLE
Fix about page layout - separate sidebar from main content

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -11,6 +11,10 @@
   animation: intro 0.3s both;
   animation-delay: 0.35s;
 
+  @media screen and (min-width: $sidebar-screen-min-width) {
+    margin-left: $sidebar-link-max-width + 2em;
+  }
+
   @include breakpoint($x-large) {
     max-width: $x-large;
   }


### PR DESCRIPTION
## Problem
The about page layout was broken with no visual separation between the left sidebar and the main content. The sidebar overlapped the main text because the main content container wasn't accounting for the fixed sidebar positioning.

## Solution
Added a left margin to the `#main` container that accounts for the sidebar width. The margin is applied within a media query (`@media screen and (min-width: $sidebar-screen-min-width)`) to only apply when the sidebar is visible at larger screen sizes (≥1024px).

The margin value is `$sidebar-link-max-width + 2em` (250px + 2em spacing) to properly accommodate the fixed sidebar.

## Changes
- Modified `_sass/_page.scss` to add left margin to `#main` element
- Uses existing SCSS variables to ensure consistency with sidebar styling

This fix ensures the main content area properly respects the space taken by the fixed sidebar without any overlap.